### PR TITLE
Update routing table in more scenarios

### DIFF
--- a/opt/wireguard/interface.sh
+++ b/opt/wireguard/interface.sh
@@ -112,6 +112,8 @@ if ! ip link show dev $INTERFACE &> /dev/null; then
 else
     # Run all configured 'down' commands
     eval "$(node_value down-command)" > /dev/null || exit 1
+    # Disable link
+    sudo ip link set down dev $INTERFACE
 fi
 
 # If interface is deleted
@@ -122,14 +124,12 @@ if [ "$ACTION" = DELETE ]; then
     exit
 fi
 
-# Disable link
-sudo ip link set down dev $INTERFACE
-
 # If disable is not set
 if ! node_exists disable; then
     # Enable link
     sudo ip link set up dev $INTERFACE
-
+    # Update routing table
+    /opt/wireguard/update_routes.sh "$INTERFACE"
     # Run all configured 'up' commands
     eval "$(node_value up-command) > /dev/null" || exit 1
 fi

--- a/opt/wireguard/peer.sh
+++ b/opt/wireguard/peer.sh
@@ -39,6 +39,12 @@ function cfg_disable() {
         cfg_endpoint
         cfg_persistent-keepalive
         cfg_preshared-key
+    # If disable is set
+    elif [ "$ACTION" = SET ]; then
+        # Remove peer
+        sudo wg set $INTERFACE peer $PEER remove
+        # Update routing table
+        /opt/wireguard/update_routes.sh "$INTERFACE"
     fi
 }
 function cfg_endpoint() {


### PR DESCRIPTION
Nothing was happening when a peer was disabled. This PR will make sure the peer is removed from WireGuard and the routing table is updated when a peer is disabled.