### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ On the USG3/4 Pro the commandline setup above does not survive reboot/re-provisi
 ```json
 {
   "firewall": {
+    "name": {
+      "WAN_LOCAL": {
+        "rule": {
+          "20": {
+            "action": "accept",
+            "description": "WireGuard",
+            "destination": {
+                    "port": "51820" //Firewall port - can be customised, adjust listen port accordingly
+            },
+            "protocol": "udp"
+          }
+        }
+      }
+    },
     "group": {
       "network-group": {
         "remote_user_vpn_network": {


### PR DESCRIPTION
The command line example configured the firewall but the persistent json file did not.
The make the examples consistent I have included the firewall configuration. 

Note that I am not a USG firewall or unifi config.json expert. I am just sharing what I found.