### PR TITLE
Add EdgeRouter X device versions (ER-10, EP‑R6) to docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -28,7 +28,7 @@ body:
       label: Device
       description: On which device are you running WireGuard
       options:
-        - EdgeRouter X (SFP) - e50
+        - EdgeRouter X (SFP, 10 X, EP-R6) - e50
         - EdgeRouter Lite / PoE - e100
         - EdgeRouter 8 (Pro) - e200
         - EdgeRouter 4 / 6P / 12 - e300

--- a/ci/release_body.md
+++ b/ci/release_body.md
@@ -22,8 +22,10 @@ Device names
 The naming scheme for source packages is a bit counter intuitive. Here is a list to find out which package is for your device.
 
 E50:
- - EdgeRouter X
- - EdgeRouter X SFP
+ - EdgeRouter X (ER-X)
+ - EdgeRouter X SFP (ER-X-SFP)
+ - EdgeRouter 10 X (ER-10X)
+ - EdgePoint 6 (EP‑R6)
 
 E100:
  - EdgeRouter Lite


### PR DESCRIPTION
Added EdgeRouter 10 X (ER-10) and EdgePoint R6 (EP‑R6) to E50 release devices

Rel: #132